### PR TITLE
Test importing orangecontrib.network._fr_layout

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
   skip: True  # [py2k]
 
@@ -31,6 +31,7 @@ requirements:
 test:
   imports:
     - orangecontrib.network
+    - orangecontrib.network._fr_layout
 
 about:
   home: https://github.com/biolab/orange3-network


### PR DESCRIPTION
#### Issue
When installing addon on windows through anaconda `Network Explorer` widget is missing.

#### Additional Info
Stack trace:
```
Could not import 'orangecontrib.network.widgets.OWNxExplorer'.
Traceback (most recent call last):
  File "C:\Users\<user>\AppData\Local\Orange\lib\site-packages\Orange\canvas\registry\discovery.py", line 261, in iter_widget_descriptions
    module = asmodule(name)
  File "C:\Users\<user>\AppData\Local\Orange\lib\site-packages\Orange\canvas\registry\discovery.py", line 493, in asmodule
    return __import__(module, fromlist=[""])
  File "C:\Users\<user>\AppData\Local\Orange\lib\site-packages\orangecontrib\network\widgets\OWNxExplorer.py", line 18, in <module>
    from orangecontrib.network.widgets.graphview import GraphView, Node, FR_ITERATIONS
  File "C:\Users\<user>\AppData\Local\Orange\lib\site-packages\orangecontrib\network\widgets\graphview.py", line 10, in <module>
    from orangecontrib.network._fr_layout import fruchterman_reingold_layout
ImportError: No module named 'orangecontrib.network._fr_layout'
```